### PR TITLE
設定ページに決済情報の登録・編集・削除を実装

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -10,4 +10,4 @@ export {
   updateArticle,
   deleteArticle
 } from './article.function';
-export { createCustomer } from './stripe.function';
+export { createCustomer, updateCustomer } from './stripe.function';

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -2,7 +2,8 @@ export {
   createUser,
   updateTwitterAvatar,
   deleteUserData,
-  deleteUserArticles
+  deleteUserArticles,
+  deleteCustomer
 } from './user.function';
 export { countUpFavorite, countDownFavorite } from './like.function';
 export {

--- a/functions/src/interfaces/card.ts
+++ b/functions/src/interfaces/card.ts
@@ -1,0 +1,10 @@
+export interface Card {
+  card: {
+    address_zip: number;
+    brand: string;
+    exp_month: number;
+    exp_year: number;
+    id: string;
+    last4: number;
+  };
+}

--- a/functions/src/stripe.function.ts
+++ b/functions/src/stripe.function.ts
@@ -15,9 +15,20 @@ export const createCustomer = functions
     }
 
     const customer = await stripe.customers.create(data);
-
     return db.doc(`customers/${context.auth.uid}`).set({
       userId: context.auth.uid,
       customerId: customer.id
     });
+  });
+
+export const updateCustomer = functions
+  .region('asia-northeast1')
+  .https.onCall((data, context) => {
+    if (!context.auth) {
+      throw new functions.https.HttpsError(
+        'permission-denied',
+        '権限がありません'
+      );
+    }
+    stripe.customers.update(data.customerId, data.params);
   });

--- a/functions/src/user.function.ts
+++ b/functions/src/user.function.ts
@@ -6,6 +6,7 @@ import { DocumentSnapshot } from 'firebase-functions/lib/providers/firestore';
 const admin = require('firebase-admin');
 admin.initializeApp();
 const db = admin.firestore();
+const stripe = require('stripe')(functions.config().stripe.key);
 
 export const updateTwitterAvatar = functions
   .region('asia-northeast1')
@@ -84,4 +85,13 @@ export const deleteUserArticles = functions
     });
 
     await batch.commit();
+  });
+
+export const deleteCustomer = functions
+  .region('asia-northeast1')
+  .auth.user()
+  .onDelete(async user => {
+    const customer = (await db.doc(`customers/${user.uid}`).get()).data();
+    stripe.customers.del(customer.customerId);
+    return db.doc(`customers/${user.uid}`).delete();
   });

--- a/src/app/search-input/search-input.component.scss
+++ b/src/app/search-input/search-input.component.scss
@@ -10,6 +10,7 @@
     padding: 0 42px 0 16px;
     box-sizing: border-box;
     border-radius: 12px;
+    background-color: #fff;
     border: 1px solid #ccc;
     outline: none;
     font-size: 16px;

--- a/src/app/services/payment.service.ts
+++ b/src/app/services/payment.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { AngularFirestore } from '@angular/fire/firestore';
 import { AngularFireFunctions } from '@angular/fire/functions';
+import { Card } from '@interfaces/card';
 
 @Injectable({
   providedIn: 'root'
@@ -21,6 +22,10 @@ export class PaymentService {
     );
   }
 
+  getCard(userId: string) {
+    return this.db.doc<Card>(`users/${userId}/private/payment`).valueChanges();
+  }
+
   createCustomer(params: {
     source: string;
     name: string;
@@ -28,5 +33,23 @@ export class PaymentService {
   }): Promise<void> {
     const callable = this.fns.httpsCallable('createCustomer');
     return callable(params).toPromise();
+  }
+
+  updateCustomer(
+    customerId: string,
+    params: {
+      source: string;
+      name: string;
+      email: string;
+    }
+  ): Promise<void> {
+    const callable = this.fns.httpsCallable('updateCustomer');
+    return callable({ customerId, params }).toPromise();
+  }
+
+  getCustomer(userId: string) {
+    return this.db
+      .doc<{ customerId: string; userId: string }>(`customers/${userId}`)
+      .valueChanges();
   }
 }

--- a/src/app/settings/settings/settings.component.html
+++ b/src/app/settings/settings/settings.component.html
@@ -19,6 +19,7 @@
               </mat-error>
             </mat-form-field>
             <button
+              class="section__button"
               (click)="changeUserName()"
               mat-flat-button
               color="primary"
@@ -49,6 +50,7 @@
               [class.active]="imageChangedEvent"
             ></image-cropper>
             <button
+              class="section__button"
               [disabled]="!croppedImage"
               (click)="changeAvatar(imageSelecter)"
               mat-flat-button
@@ -57,6 +59,7 @@
               変更する
             </button>
             <button
+              class="section__button"
               *ngIf="imageChangedEvent"
               mat-button
               (click)="resetInput(imageSelecter)"
@@ -74,9 +77,24 @@
             <p class="section__description">
               クレジットカードは世界的な決済サービスStripeによって厳重に保管されており、漏洩の心配はありません。
             </p>
-            <button mat-flat-button color="primary">
-              カードを登録する
-            </button>
+            <ng-container *ngIf="card$ | async as card; else register">
+              <div class="user-card">
+                <p>**** **** **** {{ card.card.last4 }}</p>
+                <button mat-icon-button (click)="registerCard()">
+                  <mat-icon>edit</mat-icon>
+                </button>
+              </div>
+            </ng-container>
+            <ng-template #register>
+              <button
+                class="section__button"
+                (click)="registerCard()"
+                mat-flat-button
+                color="primary"
+              >
+                カードを登録する
+              </button>
+            </ng-template>
           </div>
         </div>
       </mat-tab>
@@ -87,7 +105,12 @@
             <p class="section__description">
               退会するとすべてのデータが削除されます
             </p>
-            <button (click)="deleteAccount()" mat-flat-button color="primary">
+            <button
+              class="section__button"
+              (click)="deleteAccount()"
+              mat-flat-button
+              color="primary"
+            >
               退会する
             </button>
           </div>

--- a/src/app/settings/settings/settings.component.scss
+++ b/src/app/settings/settings/settings.component.scss
@@ -24,7 +24,7 @@ h3 {
     margin-top: 16px;
     font-size: 1.6rem;
   }
-  button {
+  &__button {
     margin: 24px auto 0;
     display: block;
   }
@@ -59,5 +59,18 @@ h3 {
     display: block;
     margin: 24px auto 0;
     width: 280px;
+  }
+}
+.user-card {
+  margin-top: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  p {
+    font-size: 18px;
+    margin-top: 6px;
+  }
+  button {
+    margin-left: 8px;
   }
 }

--- a/src/app/settings/settings/settings.component.ts
+++ b/src/app/settings/settings/settings.component.ts
@@ -1,3 +1,4 @@
+import { take } from 'rxjs/operators';
 import { MatDialog } from '@angular/material/dialog';
 import { Component, OnInit } from '@angular/core';
 import { LoadingService } from 'src/app/services/loading.service';
@@ -7,6 +8,8 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { DeleteAccountDialogComponent } from '../delete-account-dialog/delete-account-dialog.component';
 import { UserService } from 'src/app/services/user.service';
 import { ImageCroppedEvent } from 'ngx-image-cropper';
+import { CardDialogComponent } from 'src/app/shared/card-dialog/card-dialog.component';
+import { PaymentService } from 'src/app/services/payment.service';
 
 @Component({
   selector: 'app-settings',
@@ -15,7 +18,9 @@ import { ImageCroppedEvent } from 'ngx-image-cropper';
 })
 export class SettingsComponent implements OnInit {
   userId = this.authService.user.uid;
+  customerId: string;
   user$ = this.userService.getUserData(this.userId);
+  card$ = this.paymentService.getCard(this.userId);
   imageChangedEvent = '';
   croppedImage = '';
 
@@ -29,11 +34,16 @@ export class SettingsComponent implements OnInit {
     private authService: AuthService,
     private snackBar: MatSnackBar,
     private dialog: MatDialog,
-    private userService: UserService
+    private userService: UserService,
+    private paymentService: PaymentService
   ) {}
 
   ngOnInit(): void {
     this.loadingService.toggleLoading(false);
+    this.paymentService
+      .getCustomer(this.userId)
+      .pipe(take(1))
+      .subscribe(result => (this.customerId = result?.customerId));
   }
 
   changeUserName() {
@@ -70,6 +80,13 @@ export class SettingsComponent implements OnInit {
           imageSelecter.value = '';
         });
     }
+  }
+
+  registerCard() {
+    this.dialog.open(CardDialogComponent, {
+      data: { customerId: this.customerId },
+      restoreFocus: false
+    });
   }
 
   deleteAccount() {

--- a/src/app/shared/card-dialog/card-dialog.component.html
+++ b/src/app/shared/card-dialog/card-dialog.component.html
@@ -13,7 +13,14 @@
     </mat-form-field>
     <mat-form-field>
       <mat-label>メールアドレス</mat-label>
-      <input formControlName="email" matInput autocomplete="off" />
+      <input
+        type="email"
+        formControlName="email"
+        matInput
+        autocomplete="off"
+        ngModel
+        email
+      />
     </mat-form-field>
 
     <p class="form__badge">
@@ -42,6 +49,6 @@
     mat-button
     mat-flat-button
   >
-    登録する
+    {{ isEdit ? '変更' : '登録' }}する
   </button>
 </div>


### PR DESCRIPTION
### 作業内容
- 設定ページにクレジットカードの登録を実装
- 登録済みの場合に表示される、カード番号と編集ボタンを実装
- ユーザーの退会時にStripeの顧客情報も削除するように実装
<img width="729" alt="SS 2020-03-04 17 44 27" src="https://user-images.githubusercontent.com/50517283/75860827-cd632980-5e3f-11ea-955b-f626ada65c40.png">
