### PR TITLE
favicon.icoが読み込まれない不具合を修正

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -23,7 +23,7 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
             "aot": true,
-            "assets": ["src/favicon.svg", "src/favicon-dev.svg", "src/assets"],
+            "assets": ["src/favicon.ico", "src/favicon-dev.svg", "src/assets"],
             "styles": ["src/styles.scss", "src/mytheme.scss"],
             "scripts": [],
             "stylePreprocessorOptions": {


### PR DESCRIPTION
先程のプルリクだと、本番環境のFaviconが読み込まれていなかったので修正しました。
お手数お掛けして申し訳ないです 🙇‍♂️

<img width="294" alt="SS 2020-04-01 14 52 43" src="https://user-images.githubusercontent.com/50517283/78103675-78a7d400-7428-11ea-88eb-653edf4d37a1.png">